### PR TITLE
Fix environment variable concatenation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,31 @@ MAINTAINER Ming Chen
 
 ENV ANDROID_HOME="/opt/android-sdk" \
     ANDROID_NDK="/opt/android-ndk" \
+    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+
 # Get the latest version from https://developer.android.com/studio/index.html
-    ANDROID_SDK_TOOLS_VERSION="3859397" \
+ENV ANDROID_SDK_TOOLS_VERSION="3859397"
+
 # Get the latest version from https://developer.android.com/ndk/downloads/index.html
-    ANDROID_NDK_VERSION="15c" \
+ENV ANDROID_NDK_VERSION="15c"
+
 # nodejs version
-    NODE_VERSION="8.x" \
+ENV NODE_VERSION="8.x"
+
 # Set locale
-    LANG="en_US.UTF-8" \
+ENV LANG="en_US.UTF-8" \
     LANGUAGE="en_US.UTF-8" \
-    LC_ALL="en_US.UTF-8" \
-    DEBIAN_FRONTEND="noninteractive" \
-    ANDROID_SDK_HOME="$ANDROID_HOME" \
-    ANDROID_NDK_HOME="$ANDROID_NDK/android-ndk-r${ANDROID_NDK_VERSION}" \
-    PATH="$PATH:$ANDROID_SDK_HOME/tools:$ANDROID_SDK_HOME/platform-tools:$ANDROID_NDK" \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/ \
+    LC_ALL="en_US.UTF-8"
+    
+ENV DEBIAN_FRONTEND="noninteractive" \
     TERM=dumb \
     DEBIAN_FRONTEND=noninteractive
 
+# Variables must be references after they are created
+ENV ANDROID_SDK_HOME="$ANDROID_HOME"
+ENV ANDROID_NDK_HOME="$ANDROID_NDK/android-ndk-r$ANDROID_NDK_VERSION"
+
+ENV PATH="$PATH:$ANDROID_SDK_HOME/tools:$ANDROID_SDK_HOME/platform-tools:$ANDROID_NDK"
 
 COPY README.md /README.md
 
@@ -86,7 +93,7 @@ RUN echo "installing sdk tools" && \
     echo "installing ndk" && \
     wget --quiet --output-document=android-ndk.zip \
     "http://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip" && \
-    mkdir --parents "$ANDROID_NDK/android-ndk-r${ANDROID_NDK_VERSION}" && \
+    mkdir --parents "$ANDROID_NDK_HOME" && \
     unzip -q android-ndk.zip -d "$ANDROID_NDK" && \
     rm --force android-ndk.zip && \
 # Install SDKs
@@ -152,4 +159,3 @@ RUN echo "installing sdk tools" && \
     echo "installing system image with android 25 and google apis" && \
     yes | "$ANDROID_HOME"/tools/bin/sdkmanager \
         "system-images;android-25;google_apis;x86_64"
-


### PR DESCRIPTION
Environment variables cannot be referenced in the same line they are created. They need to be moved to a later ENV statement.
Also, using comments within a multi-line statement causes docker warnings, so these are now separate statements.