### PR TITLE
Issue #18 fix patch: Remove pre-installed x86_64 emulator. Explain how to create and launch an ARM emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,10 +157,7 @@ RUN echo "installing sdk tools" && \
         "add-ons;addon-google_apis-google-17" \
         "add-ons;addon-google_apis-google-16" && \
     echo "installing emulator " && \
-    yes | "$ANDROID_HOME"/tools/bin/sdkmanager "emulator" && \
-    echo "installing system image with android 25 and google apis" && \
-    yes | "$ANDROID_HOME"/tools/bin/sdkmanager \
-        "system-images;android-25;google_apis;x86_64"
+    yes | "$ANDROID_HOME"/tools/bin/sdkmanager "emulator"
 
 # Copy sdk license agreement files.
 RUN mkdir -p $ANDROID_HOME/licenses

--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ Here is an example of `bitbucket-pipelines.yml`
 If gradlew is marked as executable in your repository as recommended, remove the `chmod` command.
 
 
+### Run an Android emulator in the Docker build machine
+
+Using guidelines from https://medium.com/@AndreSand/android-emulator-on-docker-container-f20c49b129ef and https://paulemtz.blogspot.com/2013/05/android-testing-in-headless-emulator.html , you can use a script to create and launch an ARM emulator, which can be used for running integration tests or instrumentation tests or unit tests:
+
+```shell
+# Add missing folder to the PATH, to use sdkmanager and avdmanager
+ANDROID_TOOLS=$ANDROID_HOME/tools/bin
+PATH=$ANDROID_TOOLS:$PATH
+
+# Download an ARM system image to create an ARM emulator.
+sdkmanager "system-images;android-16;default;armeabi-v7a"
+
+# Create an ARM AVD emulator, with 100MB SD card storage space.
+echo "no" | avdmanager create avd \
+    -n Android_4.1_API_16 \
+    -k "system-images;android-16;default;armeabi-v7a" \
+    -c 100M \
+    --force
+
+# Launch the emulator in the background
+$ANDROID_HOME/emulator/emulator -avd Android_4.1_API_16 -no-skin -no-audio -no-window -no-boot-anim -gpu off &
+```
+
+Note that x86_64 emulators are not currently supported. See [Issue #18](https://github.com/mingchen/docker-android-build-box/issues/18) for details.
+
 ## Docker Build Image
 
 If you want to build the docker image by yourself, you can use following command.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ If gradlew is marked as executable in your repository as recommended, remove the
 
 ### Run an Android emulator in the Docker build machine
 
-Using guidelines from https://medium.com/@AndreSand/android-emulator-on-docker-container-f20c49b129ef and https://paulemtz.blogspot.com/2013/05/android-testing-in-headless-emulator.html , you can use a script to create and launch an ARM emulator, which can be used for running integration tests or instrumentation tests or unit tests:
+Using guidelines from https://medium.com/@AndreSand/android-emulator-on-docker-container-f20c49b129ef and https://spin.atomicobject.com/2016/03/10/android-test-script/ and https://paulemtz.blogspot.com/2013/05/android-testing-in-headless-emulator.html , you can use a script to create and launch an ARM emulator, which can be used for running integration tests or instrumentation tests or unit tests:
 
 ```shell
+#!/bin/bash
+
 # Add missing folder to the PATH, to use sdkmanager and avdmanager
 ANDROID_TOOLS=$ANDROID_HOME/tools/bin
 PATH=$ANDROID_TOOLS:$PATH
@@ -75,7 +77,9 @@ PATH=$ANDROID_TOOLS:$PATH
 # Download an ARM system image to create an ARM emulator.
 sdkmanager "system-images;android-16;default;armeabi-v7a"
 
-# Create an ARM AVD emulator, with 100MB SD card storage space.
+# Create an ARM AVD emulator, with a 100 MB SD card storage space. Echo "no"
+# because it will ask if you want to use a custom hardware profile, and you don't.
+# https://medium.com/@AndreSand/android-emulator-on-docker-container-f20c49b129ef
 echo "no" | avdmanager create avd \
     -n Android_4.1_API_16 \
     -k "system-images;android-16;default;armeabi-v7a" \


### PR DESCRIPTION
Fix issue #18

* Remove pre-installed x86_64 emulator system image, as it cannot run in the Docker image.
* In Readme.md, explain how to create and launch an ARM emulator in the Docker image. Mention that x86_64 emulators do not currently work.