### PR TITLE
Shell hack for avoiding Ubuntu's dash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,3 +185,6 @@ RUN mkdir -p /home/jenkins
 RUN chmod 777 /home/jenkins
 RUN chmod 777 /var/lib/jenkins/workspace
 RUN chmod 777 $ANDROID_HOME/.android
+
+# Shell hack for avoiding Ubuntu's dash
+RUN ln -sf /bin/bash /bin/sh


### PR DESCRIPTION
In Teamcity CI, the docker plugin uses `/bin/sh` for default, which will cause problems by Ubuntu's dash. Using this hack should fix this.