### PR TITLE
Updates to use ubuntu:18.04 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 MAINTAINER Ming Chen
 
@@ -46,6 +46,7 @@ RUN apt-get update -qq > /dev/null && \
         autoconf \
         curl \
         git \
+        gpg-agent \
         lib32stdc++6 \
         lib32z1 \
         lib32z1-dev \
@@ -62,7 +63,7 @@ RUN apt-get update -qq > /dev/null && \
         openjdk-8-jdk \
         openssh-client \
         pkg-config \
-        python-software-properties \
+        software-properties-common \
         ruby-full \
         software-properties-common \
         unzip \


### PR DESCRIPTION
This PR addresses the problems experienced today with apt-get update and other apt operations failing because (presumably) ubuntu:17.10 apt repositories going away.

Minor changes were required to get the build working when migrating to ubuntu:18.04 - the addition of installing gpg-agent, and replacing `python-software-properties` with `software-properties-common` when installing packages via apt.

The build completes successfully with these changes. My tests so far have been limited to my own use though.