### PR TITLE
Use NDK r20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV ANDROID_HOME="/opt/android-sdk" \
 ENV ANDROID_SDK_TOOLS_VERSION="4333796"
 
 # Get the latest version from https://developer.android.com/ndk/downloads/index.html
-ENV ANDROID_NDK_VERSION="19"
+ENV ANDROID_NDK_VERSION="20"
 
 # nodejs version
 ENV NODE_VERSION="10.x"


### PR DESCRIPTION
NDK r19 has a bug as reported [here](https://github.com/android-ndk/ndk/issues/849).

This pull request simply update NDK version to r20 on 1.10.0.
I have confirmed that this change resolves the issue with building android library with gomobile.