### PR TITLE
fixing #35 plus less/vim-tiny

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ RUN apt-get update -qq > /dev/null && \
         autoconf \
         curl \
         git \
+        file \
+        less \
+        vim-tiny \
         gpg-agent \
         lib32stdc++6 \
         lib32z1 \


### PR DESCRIPTION
fixes #35 (adds the "file" command required by ndk-build).
On top, we propose less & vim-tiny for further investigations when needed.
It adds only 2Mb to the existing 5Gb image, hope that's ok.