### PR TITLE
Update Dockerfile to install Yarn, fastlane using bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,11 +189,11 @@ RUN mkdir -p $ANDROID_HOME/licenses
 COPY sdk/licenses/* $ANDROID_HOME/licenses/
 
 # Create some jenkins required directory to allow this image run with Jenkins
-RUN mkdir -p /var/lib/jenkins/workspace
-RUN mkdir -p /home/jenkins
-RUN chmod 777 /home/jenkins
-RUN chmod 777 /var/lib/jenkins/workspace
-RUN chmod 777 $ANDROID_HOME/.android
+RUN mkdir -p /var/lib/jenkins/workspace && \
+    mkdir -p /home/jenkins && \
+    chmod 777 /home/jenkins && \
+    chmod 777 /var/lib/jenkins/workspace && \
+    chmod 777 $ANDROID_HOME/.android
 
 # Install fastlane with bundler and Gemfile
 ENV BUNDLE_GEMFILE=/tmp/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"


### PR DESCRIPTION
* Install yarn package manager
* Use bundle install to install fastlane and dependencies, Add Gemfile (#1)
* Add Gemfile, update Docker to install fastlane & dependencies via bundle install
* Make /.fastlane folder
* Update Dockerfile to add ENV BUNDLE_GEMFILE

After testing Android build using fastlane, the default fastlane installed on the image used to fail. The `/.fastlane` folder wasn't writable, and fastlane kept missing dependencies. So I installed fastlane using bundler to take care of the dependencies. I also added the yarn package manager which quite a few teams use instead of npm. Feedback welcome.