### PR TITLE
Patch for Issue #49 - Remove all the "extras" items of local libraries, in the Android SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,17 +150,6 @@ RUN echo "build tools 25-30" && \
         "build-tools;25.0.3" "build-tools;25.0.2" \
         "build-tools;25.0.1" "build-tools;25.0.0" > /dev/null
 
-RUN echo "extras repos" && \
-    yes | "$ANDROID_HOME"/tools/bin/sdkmanager \
-        "extras;android;m2repository" \
-        "extras;google;m2repository" > /dev/null
-
-RUN echo "play services & constraint-layout" && \
-    yes | "$ANDROID_HOME"/tools/bin/sdkmanager \
-        "extras;google;google_play_services" \
-        "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2" \
-        "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.1" > /dev/null
-
 RUN echo "emulator" && \
     yes | "$ANDROID_HOME"/tools/bin/sdkmanager "emulator" > /dev/null
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,7 @@ It includes the following components:
   * 29.0.2 29.0.3
   * 30.0.0
 * Android NDK r21
-* extra-android-m2repository
-* extra-google-m2repository
-* extra-google-google\_play\_services
 * Android Emulator
-* Constraint Layout
 * TestNG
 * Python 2, Python 3
 * Node.js, npm, React Native
@@ -177,7 +173,7 @@ Note that x86_64 emulators are not currently supported. See [Issue #18](https://
 ## Docker Build Image
 
 If you want to build the docker image by yourself, you can use following command.
-The image itself is more than 5 GB, check your free disk space before building it.
+The image itself is around 5 GB, so check your free disk space before building it.
 
 ```sh
 docker build -t android-build-box .


### PR DESCRIPTION
### For Issue #49

The following components are installed on the Docker images of `android-build-box`:

* extras-android-m2repository
* extras-google-m2repository
* extras-google-google_play_services
* extras-m2repository-constraint-layout-1.0.2
* extras-m2repository-constraint-layout-1.0.1

They will download about 550 MB of library dependencies to the `$ANDROID_HOME/extras` folder, which will act like a local Maven repository ("m2repository"). It contains things like Google Play Services, Android Support libraries, RecyclerView, Constraint Layout, etc.

### But I believe these items are never used anymore.

The "extras" folder is deprecated, because gradle will now download these libraries on-demand, from https://maven.google.com -- even for the very old versions. This has been available since at least July 2017. You can browse https://maven.google.com and use the search box to see all the available versions that can be downloaded. The gradle build will just ignore the extras folder, and re-download these libraries anyway.

### More info about the "extras" folder:

* https://stackoverflow.com/questions/43495549/cannot-install-support-repository-and-sync-project-in-android-studio#44926157
* https://stackoverflow.com/questions/31847847/what-is-the-use-of-libraries-in-android-sdk-extras-android-m2repository-com-andr

Observe that in Android Studio 3, it is not even possible to download the "extras" folder now, using Tools -> SDK Manager. This has been the case since about mid-2019.

So the "extras" items are now removed from the Docker image, to reduce the overall size by about 550 MB, and make it more efficient.