### PR TITLE
Make the Android SDK updatable?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,7 +192,7 @@ RUN mkdir -p /var/lib/jenkins/workspace && \
     mkdir -p /home/jenkins && \
     chmod 777 /home/jenkins && \
     chmod 777 /var/lib/jenkins/workspace && \
-    chmod -R 777 $ANDROID_HOME
+    chmod -R 775 $ANDROID_HOME
 
 # Install fastlane with bundler and Gemfile
 ENV BUNDLE_GEMFILE=/tmp/Gemfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,7 +192,7 @@ RUN mkdir -p /var/lib/jenkins/workspace && \
     mkdir -p /home/jenkins && \
     chmod 777 /home/jenkins && \
     chmod 777 /var/lib/jenkins/workspace && \
-    chmod 777 $ANDROID_HOME/.android
+    chmod -R 777 $ANDROID_HOME
 
 # Install fastlane with bundler and Gemfile
 ENV BUNDLE_GEMFILE=/tmp/Gemfile


### PR DESCRIPTION
This feature may be exactly what you *don't* want, but suggesting that the permissions for the Android SDK tools be updatable within the Docker container by Jenkins.

This pattern would fix the issue where Jenkins (as non-root user) does not have permission to update Android SDK components and built tool versions when they get updated from within an Android project's build.gradle file.

Please feel free to modify this however you like too.  Thanks