### PR TITLE
Fix issue with safe-directory in newer Git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -200,7 +200,7 @@ RUN echo "Flutter sdk" && \
     cd /opt && \
     wget --quiet https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_2.10.3-stable.tar.xz -O flutter.tar.xz && \
     tar xf flutter.tar.xz && \
-    git config --global --add safe.directory $FLUTTER_HOME \
+    git config --global --add safe.directory $FLUTTER_HOME && \
     flutter config --no-analytics && \
     rm -f flutter.tar.xz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -200,6 +200,7 @@ RUN echo "Flutter sdk" && \
     cd /opt && \
     wget --quiet https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_2.10.3-stable.tar.xz -O flutter.tar.xz && \
     tar xf flutter.tar.xz && \
+    git config --global --add safe.directory $FLUTTER_HOME \
     flutter config --no-analytics && \
     rm -f flutter.tar.xz
 


### PR DESCRIPTION
Newer versions of Git cause a problem when running `flutter pub get` inside `android-build-box` because the `/opt/flutter` directory is not considered safe to be cloned to.
See https://stackoverflow.com/questions/71849415/i-cannot-add-the-parent-directory-to-safe-directory-in-git