### PR TITLE
Improve build test

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -111,6 +111,12 @@ jobs:
         echo "Set java env to 8"
         docker run --rm $IMAGE_NAME:$TAG bash -c '. $HOME/.bash_profile && jenv local 1.8 && java -version'
 
+        echo "Test jenv recognizes Java 11"
+        docker run --rm $IMAGE_NAME:$TAG bash -c 'jenv local 11 && java -version'
+
+        echo "Test jenv recognizes Java 17"
+        docker run --rm $IMAGE_NAME:$TAG bash -c 'jenv local 17 && java -version'
+
         docker run -v `pwd`:/project --rm $IMAGE_NAME:$TAG bash -c 'echo "Current directory: $PWD"'
 
         docker run --rm $IMAGE_NAME:$TAG bash -c 'ls -l $ANDROID_SDK_HOME'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -109,7 +109,7 @@ jobs:
         docker run --rm $IMAGE_NAME:$TAG java -version
 
         echo "Set java env to 8"
-        docker run --rm $IMAGE_NAME:$TAG bash -c '. $HOME/.bash_profile; jenv local 1.8; java -version'
+        docker run --rm $IMAGE_NAME:$TAG bash -c '. $HOME/.bash_profile && jenv local 1.8 && java -version'
 
         docker run -v `pwd`:/project --rm $IMAGE_NAME:$TAG bash -c 'echo "Current directory: $PWD"'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -242,8 +242,9 @@ RUN echo "fastlane" && \
     bundle install --quiet
 
 # Add jenv to control which version of java to use, default to 17.
+ENV PATH="/root/.jenv/shims:/root/.jenv/bin${PATH:+:${PATH}}"
 RUN git clone https://github.com/jenv/jenv.git ~/.jenv && \
-    echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile && \
+    echo '#!/usr/bin/env bash' >> ~/.bash_profile && \
     echo 'eval "$(jenv init -)"' >> ~/.bash_profile && \
     . ~/.bash_profile && \
     . /etc/jdk.env && \

--- a/test_projects/SampleProject/.java-version
+++ b/test_projects/SampleProject/.java-version
@@ -1,0 +1,5 @@
+1.8
+# Sets the java version to use via jenv
+# First line must be a java version installed and recognized by `jenv versions`
+# Valid versions are always: 1.8, 11, 11.0, 17, or 17.0
+# Valid versions are sometimes: 1.8.0.352, 11.0.17, 17.0.5


### PR DESCRIPTION
I think this should resolve #108. I tested all the tests which the docker build test runs locally and they all passed.

I added jenv's `.java-version` to the SampleProject. This sets the local java version to use in that folder.

I tried to use `.bashrc` and `/etc/profile` but neither of them would work for any command of `docker run --rm $IMAGE_NAME:$TAG bash -c 'jenv versions'`. There is also setting `$BASH_ENV` and when I set that to `/root/.bash_profile` bash would just hang and not get anywhere. So I opted to resolve it by just permanently adding jenv to the PATH via the Dockerfile. The downside is when one sources `.bash_profule` there is one duplication.

I've also done some additional improvements to the docker build test.

I am reasonably confident that this should fix get the build passing.