### PR TITLE
CI: Streamline docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -89,6 +89,10 @@ jobs:
         #docker rmi $(docker images | grep -v IMAGE | awk '{print $3}')
         docker images
 
+        # Remove unneeded and installed software to free up space
+        sudo rm -rf /usr/local/lib/android/sdk
+        sudo rm -rf /opt/hostedtoolcache
+
         # check disk space one more time
         df -h
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,6 +60,8 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c
+      with:
+        driver: docker
 
     - name: Pre build
       run: |
@@ -90,13 +92,12 @@ jobs:
         # check disk space one more time
         df -h
 
-    - name: Build local docker image for test
-      # if: github.event_name != 'pull_request'
-      run: |
-        TAG=$GITHUB_SHA
-        docker build . \
-            --file Dockerfile \
-            --tag ${{ env.IMAGE_NAME}}:${{ env.TAG}}
+    - name: Build and load local docker image for test
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        load: true
+        tags: ${{ env.IMAGE_NAME}}:${{ env.TAG}}
 
     - name: Inspect local docker image
       run: |


### PR DESCRIPTION
Change to build the image using docker action. Subsequently reducing build time
~50%, as the image will only need to be built once. Currently image is
built twice.

The default driver uses double the disk space, see
https://github.com/docker/build-push-action/issues/321 (in brief, the image is built in the
build-push-action local cache, `tar`ed, and then transfered to the local docker).
This is a problem as this image is so large. Using the `docker` driver
will workaround this.

Removes the Android SDK and the Hosted tool cache from the runner.
The hostedtoolcache has the following unused software:
- PyPy
- go
- CodeQL
- Java_Temurin-Hotspot_jdk
- node
- Ruby
- Python

This frees up ~23G from the disk space.