### PR TITLE
CI: Fix dockerhub-description password

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -188,6 +188,6 @@ jobs:
       uses: peter-evans/dockerhub-description@579f64ca0abced29dbbc44ab4c6a0b9e33ab3588
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: mingc/android-build-box
         enable-url-completion: true


### PR DESCRIPTION
This should fix the CI dockerhub description update. #124 used the wrong key.