### PR TITLE
Upgrade to Ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -93,7 +93,7 @@ jobs:
         echo "TAG: $TAG"
 
         # Remove exist images to free disk space
-        docker rmi $(docker image ls -a | grep -vE 'ubuntu.*20\.04|moby/buildkit' | awk 'NR>1 {print $3}')
+        docker rmi $(docker image ls -a | grep -vE 'ubuntu.*22\.04|moby/buildkit' | awk 'NR>1 {print $3}')
         #docker rmi $(docker images | grep -v IMAGE | awk '{print $3}')
         docker images
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG JENV_RELEASE="0.5.6"
 #----------~~~~~~~~~~*****
 # build stage: ubunutu
 #----------~~~~~~~~~~*****
-FROM ubuntu:20.04 as ubuntu
+FROM ubuntu:22.04 as ubuntu
 # Ensure ARGs are in this build context
 ARG ANDROID_SDK_TOOLS_VERSION
 ARG NDK_VERSION


### PR DESCRIPTION
Upgrade to use hopefully use a later version of ruby by default allowing for latest bundler to be used. Using 20.04 causes bundler to fail to install due to Ruby 2.7 being used instead of the required 3.0.