### PR TITLE
Improve docker hub latest

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -187,7 +187,7 @@ jobs:
     - name: Modify Readme to list latest software
       if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master')
       run: |
-        printf "\n\n \"Latest\" Tag Software:\n\n" >> README.md
+        printf "\n\n ## \"Latest\" Tag Software:\n\n" >> README.md
         TEMP=$(docker run --rm ${{ env.IMAGE_NAME}}:${{ env.TAG}} cat '/root/installed-versions.txt')
         echo "$TEMP" | tail --lines=+2 >> README.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -306,7 +306,7 @@ RUN wget -q https://github.com/google/bundletool/releases/download/${BUNDLETOOL_
 FROM bundletool-base as bundletool-latest
 RUN TEMP=$(curl -s https://api.github.com/repos/google/bundletool/releases/latest) && \
     echo "$TEMP" | grep "browser_download_url.*jar" | cut -d : -f 2,3 | tr -d \" | wget -O $ANDROID_SDK_HOME/cmdline-tools/latest/bundletool.jar -qi - && \
-    TAG_NAME=$(echo "$TEMP" | grep "tag_name" | cut -d : -f 2,3 | tr -d \"\ ,) && \
+    TAG_NAME=$(echo "$TEMP" | grep "tag_name" | cut -d : -f 2,3 | tr -d '",') && \
     echo "BUNDLETOOL_VERSION=$TAG_NAME" >> ${INSTALLED_TEMP}
 
 FROM bundletool-${BUNDLETOOL_TAGGED} as bundletool-final


### PR DESCRIPTION
This changes the Dockerhub "latest" header to be formatted correctly.

This also changes how the Bundletool Version is grabbed for "latest" allowing the version to hopefully be displayed correctly on the Dockerhub description and in the `INSTALLED_VERSIONS`.