### PR TITLE
CI: Fixup build and push #178 & minor improvements

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -171,18 +171,33 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push
+    - name: Build and push - for Not PRs and Not Tags
       uses: docker/build-push-action@v5.1.0
+      if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/')
       with:
         context: .
-        # Android SDK not support arm64 yet
-        # platforms: linux/amd64,linux/arm64
         platforms: linux/amd64
-        # platforms: linux/arm64
-        # push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
-        push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')) }}
-        tags: mingc/android-build-box:latest,${{ steps.meta.outputs.tags }}
+        push: ${{ github.ref == 'refs/heads/master' }}
+        tags: mingc/android-build-box:latest, ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Build and push - for Not PRs and Tags
+      uses: docker/build-push-action@v5.1.0
+      if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')
+      with:
+        context: .
+        platforms: linux/amd64
+        push: ${{ contains(github.ref, 'refs/tags/') }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          ANDROID_SDK_TOOLS_TAGGED=tagged
+          ANDROID_SDKS=tagged
+          NDK_TAGGED=tagged
+          NODE_TAGGED=tagged
+          BUNDLETOOL_TAGGED=tagged
+          FLUTTER_TAGGED=tagged
+          JENV_TAGGED=tagged
 
     - name: Modify Readme to list latest software
       if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master')

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,7 +51,7 @@ jobs:
           org.opencontainers.image.vendor=Ming Chen
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
       with:
         platforms: amd64,arm64
 
@@ -105,7 +105,7 @@ jobs:
         df -h
 
     - name: Build and load local docker image for PRs or Not Tags
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
       if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/tags/')
       with:
         context: .
@@ -113,7 +113,7 @@ jobs:
         tags: ${{ env.IMAGE_NAME}}:${{ env.TAG}}
 
     - name: Build and load local docker image for Not PRs and Tags
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
       if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')
       with:
         context: .
@@ -166,13 +166,13 @@ jobs:
     - name: Login to DockerHub
       # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
       if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
-      uses: docker/login-action@v3
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and push - for Not PRs and Not Tags
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
       if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/')
       with:
         context: .
@@ -182,7 +182,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build and push - for Not PRs and Tags
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
       if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')
       with:
         context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -165,7 +165,7 @@ jobs:
 
     - name: Login to DockerHub
       # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
-      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/'))
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -177,7 +177,7 @@ jobs:
       with:
         context: .
         platforms: linux/amd64
-        push: ${{ github.ref == 'refs/heads/master' }}
+        push: ${{ startsWith(github.ref, 'refs/heads/master') }}
         tags: mingc/android-build-box:latest, ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
@@ -187,7 +187,7 @@ jobs:
       with:
         context: .
         platforms: linux/amd64
-        push: ${{ contains(github.ref, 'refs/tags/') }}
+        push: ${{ startsWith(github.ref, 'refs/tags/') }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |


### PR DESCRIPTION
When tags where build & pushed to Docker Hub, the build arguments added in as a result of https://github.com/mingchen/docker-android-build-box/issues/116 where not included. This fix should make the tagged version use the correct build arguments. By doing so the correct docker image should be built and pushed to Docker Hub.

Tags which are affected by this on Docker Hub which should be re-pushed are `1.27.0` and `1.26.0`.

This should resolve #178 .