### PR TITLE
Add missing Ninja package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get update -qq > /dev/null && \
         autoconf \
         build-essential \
         cmake \
+        ninja-build \
         curl \
         file \
         git \


### PR DESCRIPTION
This pull request adds missing [Ninja C++ build system](https://github.com/ninja-build/ninja) package that is used as the [experimental C/C++ build system](https://developer.android.com/build/cxx-ninja) for Android builds.
This package is distributed for Ubuntu as `ninja-build` package.

Without this package, some builds might fail by not being able to find this binary:
```
> Task :app:configureCMakeRelWithDebInfo[armeabi-v7a] FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:configureCMakeRelWithDebInfo[armeabi-v7a]'.
> [CXX1416] Could not find Ninja on PATH or in SDK CMake bin folders.
```

