### PR TITLE
Updates / Changes for proposed Next Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # when _TAGGED is "tagged" the version in _VERSION will be used.
 # _TAGGED is used to handle the build stages
 
-# "11076708" as of 2024/03/04
+# "13114758" as of 2025/04/04
 ARG ANDROID_SDK_TOOLS_TAGGED="latest"
-ARG ANDROID_SDK_TOOLS_VERSION="11076708"
+ARG ANDROID_SDK_TOOLS_VERSION="13114758"
 
 # Valid values are "last8" or "tagged"
 # "last8" will grab the last 8 android-sdks, including extensions and
@@ -13,16 +13,16 @@ ARG ANDROID_SDK_TOOLS_VERSION="11076708"
 ARG ANDROID_SDKS="last8"
 
 ARG NDK_TAGGED="latest"
-ARG NDK_VERSION="26.2.11394342"
+ARG NDK_VERSION="28.0.13004108"
 
 ARG NODE_TAGGED="latest"
-ARG NODE_VERSION="20.x"
+ARG NODE_VERSION="22.x"
 
 ARG BUNDLETOOL_TAGGED="latest"
-ARG BUNDLETOOL_VERSION="1.15.6"
+ARG BUNDLETOOL_VERSION="1.18.1"
 
 ARG FLUTTER_TAGGED="latest"
-ARG FLUTTER_VERSION="3.19.2"
+ARG FLUTTER_VERSION="3.24.5"
 
 ARG JENV_TAGGED="latest"
 ARG JENV_RELEASE="0.5.6"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The last **tagged** release includes the following components:
   * 32
   * 33
   * 34
+  * 35
 * Android build tools:
   * 28.0.1 28.0.2 28.0.3
   * 29.0.2 29.0.3
@@ -37,13 +38,14 @@ The last **tagged** release includes the following components:
   * 32.0.0
   * 33.0.0 33.0.1 33.0.2 33.0.3
   * 34.0.0
-* Android NDK - r26c
+  * 35.0.0
+* Android NDK - r28c
 * [Android bundletool](https://github.com/google/bundletool)
 * Android Emulator
 * cmake
 * TestNG
 * Python 3.8.10
-* Node.js 20, npm, React Native
+* Node.js 22, npm, React Native
 * Ruby, RubyGems
 * fastlane
 * Flutter 3.16.9

--- a/tagged_sdk_packages_list.txt
+++ b/tagged_sdk_packages_list.txt
@@ -1,3 +1,4 @@
+platforms;android-35
 platforms;android-34
 platforms;android-33
 platforms;android-32
@@ -5,6 +6,7 @@ platforms;android-31
 platforms;android-30
 platforms;android-29
 platforms;android-28
+build-tools;35.0.0
 build-tools;34.0.0
 build-tools;33.0.3
 build-tools;33.0.2


### PR DESCRIPTION
- Add Android Platform 35
- Upgrade Flutter 3.19.2 -> 3.24.5
- Upgrade bundletool 1.15.6 -> 1.18.1
- Upgrade 20.x (also LTS) -> 22.x
- Upgrade to latest Android CLT 13114758
- Upgrade Android NDK r26c -> r28c